### PR TITLE
[Win32] Fix for perl configuration of 'ivsize = 4' && 'nvtype eq __float128'

### DIFF
--- a/lib/Math/BigInt/Calc.pm
+++ b/lib/Math/BigInt/Calc.pm
@@ -141,7 +141,7 @@ BEGIN {
             $num *= $num + 1;
         } while ("$num" =~ /9{$e1}0{$e1}/); # must be a certain pattern
         $e1--;                  # last test failed, so retract one step
-        if ($e1 > 7) {
+        if ($e1 >= 7) {
             $int = 1;
             $e = $e1;
         }


### PR DESCRIPTION
Hi,
In porting USE_QUADMATH builds to native Windows, I built a (32-bit) perl whose ivsize was '4' and whose nvtype was __float128.
There were a few failing Math::BigInt/BigFloat tests - see attached fail.txt.
I'm not surprised if this is the first time that such an ivsize/nvtype combination has been tested. It was the only configuration that reported this failure.

As the patch shows, the proposed fix is simply to do a =~s/>/>=/ near the end of the BEGIN block in Calc.pm.

With that change in place, on my Windows 7 box running current blead, I checked all (six) ivsize/nvype permutations - ie ivsize of 4 and 8 x nvtype of 'double', 'long double' and '__float128'. 
All tests passed for each of the configurations.

However, I didn't reach an understanding of what was going on in the affected section of the code.
I just tracked a diversion in behaviour down to that section of code, and wondered what would happen if I changed the '>' to '>=' and it worked ... for some meaning of "worked", at least.
Perhaps my solution is sub-optimal ... or perhaps it breaks some aspect(s) of Math::BigInt/BigFloat, not covered by the test suite.

[fail.txt](https://github.com/pjacklam/p5-Math-BigInt/files/5793668/fail.txt)

Note that the PR that enables USE_QUADMATH on Windows was merged into blead just an hour or so ago.

Cheers,
Rob


