### PR TITLE
Remove links to annocpan.org

### DIFF
--- a/lib/Math/BigInt/Lib.pm
+++ b/lib/Math/BigInt/Lib.pm
@@ -2588,10 +2588,6 @@ You can also look for information at:
 
 L<https://rt.cpan.org/Public/Dist/Display.html?Name=Math-BigInt>
 
-=item * AnnoCPAN: Annotated CPAN documentation
-
-L<http://annocpan.org/dist/Math-BigInt>
-
 =item * CPAN Ratings
 
 L<https://cpanratings.perl.org/dist/Math-BigInt>


### PR DESCRIPTION
annocpan.org has lapsed and is now hosting some kind of link farm